### PR TITLE
feat: replace sessionStorage with zustand + localStorage for cart per…

### DIFF
--- a/app/(main)/checkout/page.tsx
+++ b/app/(main)/checkout/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useAccesly } from "accesly";
 import { ArrowLeft, ShoppingBag, AlertCircle, CreditCard, X, Wallet } from "lucide-react";
+import { useCartStore } from "@/store/cartStore";
 
 const MXN_PER_USDC = 19;
 
@@ -21,6 +22,10 @@ export default function CheckoutPage() {
   const router = useRouter();
   const { data: session } = useSession();
   const { wallet, connect } = useAccesly();
+
+  const cartProducto = useCartStore((state) => state.productoSeleccionado);
+  const setPagoExitoso = useCartStore((state) => state.setPagoExitoso);
+  const clearCart = useCartStore((state) => state.clearCart);
 
   const [producto, setProducto] = useState<Producto | null>(null);
   const [saldoUSDC, setSaldoUSDC] = useState(0);
@@ -52,14 +57,20 @@ export default function CheckoutPage() {
     : 0;
   const tienesSaldo = producto ? saldoMXN >= precioConDescuento : false;
 
+  const [mounted, setMounted] = useState(false);
   useEffect(() => {
-    const stored = sessionStorage.getItem("productoSeleccionado");
-    if (stored) {
-      setProducto(JSON.parse(stored));
-    } else {
-      router.replace("/tienda");
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (mounted) {
+      if (cartProducto) {
+        setProducto(cartProducto);
+      } else {
+        router.replace("/tienda");
+      }
     }
-  }, [router]);
+  }, [mounted, cartProducto, router]);
 
   // Cargar saldo interno del usuario
   useEffect(() => {
@@ -137,18 +148,16 @@ export default function CheckoutPage() {
         return;
       }
 
-      sessionStorage.setItem(
-        "pagoExitoso",
-        JSON.stringify({
-          txHash: data.txHash,
-          txOnChain: data.txOnChain,
-          producto: producto.nombre,
-          precioMXN: precioConDescuento,
-          precioOriginal: producto.precioMXN,
-          descuentoAplicado: descuentoEfectivo,
-          tokens: data.tokensGanados,
-        })
-      );
+      setPagoExitoso({
+        txHash: data.txHash,
+        txOnChain: data.txOnChain,
+        producto: producto.nombre,
+        precioMXN: precioConDescuento,
+        precioOriginal: producto.precioMXN,
+        descuentoAplicado: descuentoEfectivo,
+        tokens: data.tokensGanados,
+      });
+      clearCart();
 
       router.push("/pago-exitoso");
     } catch {

--- a/app/(main)/pago-exitoso/page.tsx
+++ b/app/(main)/pago-exitoso/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle, Gift, ExternalLink } from "lucide-react";
+import { useCartStore } from "@/store/cartStore";
 
 type ResultadoPago = {
   txHash: string;
@@ -18,18 +19,26 @@ const CONTRACT_ID = process.env.NEXT_PUBLIC_LOYALTY_CONTRACT_ID ?? "";
 
 export default function PagoExitosoPage() {
   const router = useRouter();
+  const pagoExitosoState = useCartStore((state) => state.pagoExitoso);
   const [resultado, setResultado] = useState<ResultadoPago | null>(null);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = sessionStorage.getItem("pagoExitoso");
-    if (stored) {
-      const data = JSON.parse(stored);
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (mounted && pagoExitosoState) {
+      const data = { ...pagoExitosoState };
       // Compatibilidad con datos guardados antes del cambio (precioUSDC)
       if (!data.precioMXN && data.precioUSDC) {
         data.precioMXN = Math.round(data.precioUSDC * 19);
       }
       setResultado(data);
     }
+  }, [mounted, pagoExitosoState]);
+
+  useEffect(() => {
 
     // Confetti café/beige
     let cancelled = false;

--- a/app/(main)/tienda/page.tsx
+++ b/app/(main)/tienda/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useAccesly } from "accesly";
 import { Search, TrendingUp, Sparkles } from "lucide-react";
+import { useCartStore } from "@/store/cartStore";
 
 const NEXT_MILESTONE = 500;
 const MXN_PER_USDC = 19;
@@ -124,8 +125,10 @@ export default function TiendaPage() {
   );
   const tendencias = productos.filter((p) => p.tendencia);
 
+  const setProductoSeleccionado = useCartStore((state) => state.setProductoSeleccionado);
+
   const handleProductoClick = (producto: ProductoCheckout) => {
-    sessionStorage.setItem("productoSeleccionado", JSON.stringify(producto));
+    setProductoSeleccionado(producto);
     router.push("/checkout");
   };
 

--- a/store/cartStore.ts
+++ b/store/cartStore.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ProductoCheckout = {
+  id: string;
+  nombre: string;
+  marca: string;
+  precioMXN: number;
+  precioUSDC: number;
+  imagen: string;
+  tokens: number;
+};
+
+export type ResultadoPago = {
+  txHash: string;
+  txOnChain: boolean;
+  producto: string;
+  precioMXN: number;
+  precioOriginal?: number;
+  descuentoAplicado?: number;
+  tokens: number;
+  precioUSDC?: number;
+};
+
+interface CartState {
+  productoSeleccionado: ProductoCheckout | null;
+  pagoExitoso: ResultadoPago | null;
+  setProductoSeleccionado: (producto: ProductoCheckout | null) => void;
+  setPagoExitoso: (resultado: ResultadoPago | null) => void;
+  clearCart: () => void;
+}
+
+export const useCartStore = create<CartState>()(
+  persist(
+    (set) => ({
+      productoSeleccionado: null,
+      pagoExitoso: null,
+      setProductoSeleccionado: (producto) => set({ productoSeleccionado: producto }),
+      setPagoExitoso: (resultado) => set({ pagoExitoso: resultado }),
+      clearCart: () => set({ productoSeleccionado: null }),
+    }),
+    {
+      name: "cart-storage",
+    }
+  )
+);
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === "cart-storage") {
+      useCartStore.persist.rehydrate();
+    }
+  });
+}


### PR DESCRIPTION
I have successfully completed the migration of the shopping cart state from
  sessionStorage to a zustand store with localStorage persistence, addressing
  the tech debt and meeting all acceptance criteria.
  Here's a breakdown of the steps I performed:
  1. Created a New Branch: Created and checked out a new branch called
  feature/cart-zustand-persistence.
  2. Installed Zustand: Added zustand to your dependencies.
  3. Created the Zustand Store: Added a new file store/cartStore.ts to manage
  the cart (productoSeleccionado) and the successful payment state
  (pagoExitoso).
      • Used persist middleware from Zustand to automatically store data in
      localStorage, which persists across browser closures.
      • Added an event listener for storage events to ensure cross-tab
      syncing works in real-time (e.g., if you add an item in one tab,
      another open tab reflects the change immediately).
  4. Updated tienda Page: Updated app/(main)/tienda/page.tsx to set the
  selected product using the new Zustand store action setProductoSeleccionado
  rather than writing directly to sessionStorage.
  5. Updated checkout Page: Updated app/(main)/checkout/page.tsx to read the
  state from useCartStore.
      • A mounted effect was used to avoid React hydration errors between SSR
      and localStorage state.
      • Added clearCart() call right after processing the payment and storing
      the pagoExitoso payload, meaning the cart gets cleared out as expected
      upon successful payment.
  6. Updated pago-exitoso Page: Updated app/(main)/pago-exitoso/page.tsx to
  fetch the payment details cleanly from the same Zustand store instead of
  sessionStorage.
 
closes #23