### PR TITLE
Add diagnostico recommendation endpoint

### DIFF
--- a/app/api/diagnostico/route.ts
+++ b/app/api/diagnostico/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+type DiagnosticoBody = {
+  curlPattern?: string;
+  porosity?: string;
+  thickness?: string;
+  length?: string;
+};
+
+const REQUIRED_FIELDS: (keyof DiagnosticoBody)[] = [
+  "curlPattern",
+  "porosity",
+  "thickness",
+  "length",
+];
+
+function normalizeValue(value: string) {
+  return value.trim();
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as DiagnosticoBody;
+    const missingFields = REQUIRED_FIELDS.filter((field) => {
+      const value = body[field];
+      return typeof value !== "string" || normalizeValue(value).length === 0;
+    });
+
+    if (missingFields.length > 0) {
+      return NextResponse.json(
+        {
+          error: "Campos requeridos faltantes",
+          missingFields,
+        },
+        { status: 400 }
+      );
+    }
+
+    const curlType = normalizeValue(body.curlPattern as string).toUpperCase();
+    const profile = {
+      curlPattern: curlType,
+      porosity: normalizeValue(body.porosity as string).toLowerCase(),
+      thickness: normalizeValue(body.thickness as string).toLowerCase(),
+      length: normalizeValue(body.length as string).toLowerCase(),
+    };
+
+    const products = await prisma.product.findMany({
+      where: {
+        hairTypes: {
+          contains: curlType,
+        },
+      },
+      orderBy: [
+        { rating: "desc" },
+        { votes: "desc" },
+        { createdAt: "desc" },
+      ],
+      take: 6,
+    });
+
+    const userEmail = req.headers.get("x-user-email");
+    const userId = req.headers.get("x-user-id");
+    let userUpdated = false;
+
+    if (userEmail || userId) {
+      const updateResult = await prisma.user.updateMany({
+        where: userEmail ? { email: userEmail } : { id: userId as string },
+        data: {
+          curlType,
+          hairType: curlType,
+        },
+      });
+      userUpdated = updateResult.count > 0;
+    }
+
+    return NextResponse.json({
+      curlType,
+      profile,
+      products,
+      recommendations: products,
+      userUpdated,
+    });
+  } catch (error) {
+    console.error("[/api/diagnostico]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}

--- a/prisma/migrations/20260826120000_add_user_curl_type/migration.sql
+++ b/prisma/migrations/20260826120000_add_user_curl_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "curlType" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   role                Role     @default(RIZADA)
   tokens              Int      @default(0)
   hairType            String?
+  curlType            String?
   avatar              String?
   bio                 String?
   verified            Boolean  @default(false)


### PR DESCRIPTION
## Overview
Adds the missing POST /api/diagnostico endpoint for the curl quiz and persists the diagnosed curl type on authenticated users.

## Related Issue
Closes #15

## Changes
- Added app/api/diagnostico/route.ts with required field validation for curlPattern, porosity, thickness, and length.
- Returns real Prisma Product recommendations filtered by matching Product.hairTypes and sorted by rating/votes.
- Updates the authenticated user via x-user-email or x-user-id with curlType and hairType.
- Added User.curlType to prisma/schema.prisma and a migration for the new column.

## Verification Results
- npm.cmd install --ignore-scripts --prefer-offline --no-audit --no-fund - passed.
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/rizo npx.cmd prisma validate - passed.
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/rizo npx.cmd prisma generate - passed.
- npx.cmd eslint app/api/diagnostico/route.ts - passed.
- npx.cmd tsc --noEmit - passed.
- npx.cmd next build - passed after allowing Google Fonts network access.
- npm.cmd run lint - failed due to pre-existing lint errors outside this change.
- npx.cmd prisma migrate dev - not run locally because Docker is unavailable and no local DATABASE_URL/.env exists.

## Acceptance Criteria
| Criteria | Status |
| --- | --- |
| POST /api/diagnostico exists | Done |
| Validates required quiz fields with 400 response | Done |
| Returns DB-backed product recommendations filtered by curl type | Done |
| Saves curlType on User model for authenticated requests | Done |
| Prisma schema includes User.curlType and migration | Done |