### PR TITLE
feat: Transactional emails: Welcome, purchase confirmation, and passw…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,9 @@
       "Bash(cargo build:*)",
       "Bash(cargo test:*)",
       "Bash(xargs grep:*)",
-      "Bash(npx --no -- prisma generate)"
+      "Bash(npx --no -- prisma generate)",
+      "Bash(npm ls *)",
+      "Bash(npm -v)"
     ]
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,20 @@ NEXTAUTH_URL="http://localhost:3000"
 
 
 # =============================================================================
+# RESEND — Transactional Email
+# =============================================================================
+
+# API key used to send welcome, purchase confirmation, and password reset emails.
+# Get it from: https://resend.com/api-keys
+RESEND_API_KEY=""
+
+# "From" address used for all transactional emails. Must be a verified sender
+# or domain in your Resend account.
+# Format: "Display Name <email@domain.com>" or just "email@domain.com"
+EMAIL_FROM="noreply@rizo.app"
+
+
+# =============================================================================
 # PRIVY — Wallet & Social Login
 # =============================================================================
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -73,7 +73,7 @@ export default function LoginPage() {
           </div>
 
           <div className="text-right">
-            <Link href="#" className="text-xs text-[#8D6E63] hover:underline">
+            <Link href="/olvide-password" className="text-xs text-[#8D6E63] hover:underline">
               Olvidaste tu contrasena?
             </Link>
           </div>

--- a/app/(auth)/olvide-password/page.tsx
+++ b/app/(auth)/olvide-password/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+import Link from "next/link";
+import { useState } from "react";
+
+export default function OlvidePasswordPage() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [enviado, setEnviado] = useState(false);
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Error al procesar la solicitud");
+        return;
+      }
+
+      setEnviado(true);
+    } catch {
+      setError("Error de conexion, intenta de nuevo");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="text-center mb-8">
+        <Link href="/" className="inline-flex items-center gap-2">
+          <span className="text-[#8D6E63] text-xl">o</span>
+          <span className="text-2xl font-bold text-[#3E2723]" style={{ fontFamily: "var(--font-playfair)" }}>RIZO</span>
+        </Link>
+        <p className="text-sm text-[#8D6E63] mt-2">Recupera el acceso a tu cuenta</p>
+      </div>
+
+      <div className="bg-white rounded-3xl p-8 shadow-sm border border-[#D7CCC8]">
+        <h1 className="text-2xl font-bold text-[#3E2723] mb-2" style={{ fontFamily: "var(--font-playfair)" }}>
+          Olvidaste tu contrasena?
+        </h1>
+
+        {enviado ? (
+          <p className="text-sm text-[#6D4C41] mt-4">
+            Si el correo <strong>{email}</strong> esta registrado, recibiras un enlace para
+            restablecer tu contrasena en los proximos minutos. El enlace expira en 1 hora.
+          </p>
+        ) : (
+          <>
+            <p className="text-xs text-[#8D6E63] mb-6">
+              Ingresa tu correo y te enviaremos un enlace para restablecerla.
+            </p>
+
+            {error && (
+              <div className="bg-[#FBEAF2] border border-[#D7CCC8] rounded-xl px-4 py-3 text-xs text-[#993556] mb-4">
+                {error}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-[#6D4C41]">Correo electronico</label>
+                <input type="email" value={email} onChange={(e) => setEmail(e.target.value)}
+                  placeholder="tu@correo.com"
+                  onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                  className="w-full bg-[#FAF8F5] border border-[#D7CCC8] rounded-xl px-4 py-3 text-sm text-[#3E2723] placeholder-[#BCAAA4] focus:outline-none focus:border-[#8D6E63] transition-colors" />
+              </div>
+
+              <button
+                onClick={handleSubmit}
+                disabled={loading || !email}
+                className="w-full bg-[#8D6E63] text-white py-3 rounded-xl text-sm font-medium hover:bg-[#6D4C41] transition-colors disabled:opacity-40 disabled:cursor-not-allowed mt-2">
+                {loading ? "Enviando..." : "Enviar enlace"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <p className="text-center text-xs text-[#8D6E63] mt-6">
+        <Link href="/login" className="text-[#8D6E63] font-medium hover:underline">
+          Volver a iniciar sesion
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(auth)/restablecer-password/page.tsx
+++ b/app/(auth)/restablecer-password/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+import Link from "next/link";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function RestablecerPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [exito, setExito] = useState(false);
+
+  const handleSubmit = async () => {
+    setError("");
+
+    if (!token) {
+      setError("El enlace no es valido. Solicita uno nuevo.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("La contrasena debe tener al menos 8 caracteres");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Las contrasenas no coinciden");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "El enlace es invalido o ha expirado");
+        return;
+      }
+
+      setExito(true);
+      setTimeout(() => router.push("/login"), 2500);
+    } catch {
+      setError("Error de conexion, intenta de nuevo");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="text-center mb-8">
+        <Link href="/" className="inline-flex items-center gap-2">
+          <span className="text-[#8D6E63] text-xl">o</span>
+          <span className="text-2xl font-bold text-[#3E2723]" style={{ fontFamily: "var(--font-playfair)" }}>RIZO</span>
+        </Link>
+        <p className="text-sm text-[#8D6E63] mt-2">Elige una nueva contrasena</p>
+      </div>
+
+      <div className="bg-white rounded-3xl p-8 shadow-sm border border-[#D7CCC8]">
+        <h1 className="text-2xl font-bold text-[#3E2723] mb-6" style={{ fontFamily: "var(--font-playfair)" }}>
+          Restablecer contrasena
+        </h1>
+
+        {exito ? (
+          <p className="text-sm text-[#6D4C41]">
+            Tu contrasena fue actualizada. Redirigiendo al inicio de sesion...
+          </p>
+        ) : (
+          <>
+            {!token && (
+              <div className="bg-[#FBEAF2] border border-[#D7CCC8] rounded-xl px-4 py-3 text-xs text-[#993556] mb-4">
+                Este enlace no incluye un token valido. Solicita uno nuevo desde{" "}
+                <Link href="/olvide-password" className="underline">olvide mi contrasena</Link>.
+              </div>
+            )}
+
+            {error && (
+              <div className="bg-[#FBEAF2] border border-[#D7CCC8] rounded-xl px-4 py-3 text-xs text-[#993556] mb-4">
+                {error}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-[#6D4C41]">Nueva contrasena</label>
+                <input type="password" value={password} onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Minimo 8 caracteres"
+                  className="w-full bg-[#FAF8F5] border border-[#D7CCC8] rounded-xl px-4 py-3 text-sm text-[#3E2723] placeholder-[#BCAAA4] focus:outline-none focus:border-[#8D6E63] transition-colors" />
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-[#6D4C41]">Confirmar contrasena</label>
+                <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Repite la contrasena"
+                  onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                  className="w-full bg-[#FAF8F5] border border-[#D7CCC8] rounded-xl px-4 py-3 text-sm text-[#3E2723] placeholder-[#BCAAA4] focus:outline-none focus:border-[#8D6E63] transition-colors" />
+              </div>
+
+              <button
+                onClick={handleSubmit}
+                disabled={loading || !password || !confirmPassword}
+                className="w-full bg-[#8D6E63] text-white py-3 rounded-xl text-sm font-medium hover:bg-[#6D4C41] transition-colors disabled:opacity-40 disabled:cursor-not-allowed mt-2">
+                {loading ? "Guardando..." : "Guardar nueva contrasena"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function RestablecerPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <RestablecerPasswordForm />
+    </Suspense>
+  );
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+import { randomBytes, createHash } from "crypto";
+import { sendPasswordResetEmail } from "@/lib/email";
+
+const prisma = new PrismaClient();
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hora
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+// Solicita un enlace de restablecimiento de contraseña.
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+
+    if (!email) {
+      return NextResponse.json({ error: "El correo es requerido" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+
+    // Respuesta genérica siempre — no revelar si el correo existe o no.
+    if (user) {
+      const rawToken = randomBytes(32).toString("hex");
+
+      await prisma.passwordResetToken.create({
+        data: {
+          userId: user.id,
+          tokenHash: hashToken(rawToken),
+          expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+        },
+      });
+
+      const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+      const resetUrl = `${baseUrl}/restablecer-password?token=${rawToken}`;
+
+      await sendPasswordResetEmail({
+        to: user.email,
+        name: user.name ?? "",
+        resetUrl,
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Si el correo existe, recibirás un enlace para restablecer tu contraseña.",
+    });
+  } catch (error) {
+    console.error("[/api/auth/reset-password] POST Error:", error);
+    return NextResponse.json({ error: "Error interno del servidor" }, { status: 500 });
+  }
+}
+
+// Confirma el restablecimiento con el token de un solo uso.
+export async function PUT(req: NextRequest) {
+  try {
+    const { token, password } = await req.json();
+
+    if (!token || !password) {
+      return NextResponse.json(
+        { error: "Token y contraseña son requeridos" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof password !== "string" || password.length < 8) {
+      return NextResponse.json(
+        { error: "La contraseña debe tener al menos 8 caracteres" },
+        { status: 400 }
+      );
+    }
+
+    const resetToken = await prisma.passwordResetToken.findUnique({
+      where: { tokenHash: hashToken(token) },
+    });
+
+    if (!resetToken || resetToken.usedAt || resetToken.expiresAt < new Date()) {
+      return NextResponse.json(
+        { error: "El enlace es inválido o ha expirado" },
+        { status: 400 }
+      );
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: resetToken.userId },
+        data: { password: hashedPassword },
+      }),
+      prisma.passwordResetToken.update({
+        where: { id: resetToken.id },
+        data: { usedAt: new Date() },
+      }),
+    ]);
+
+    return NextResponse.json({ success: true, message: "Contraseña actualizada correctamente" });
+  } catch (error) {
+    console.error("[/api/auth/reset-password] PUT Error:", error);
+    return NextResponse.json({ error: "Error interno del servidor" }, { status: 500 });
+  }
+}

--- a/app/api/compra/route.ts
+++ b/app/api/compra/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 import * as StellarSdk from "@stellar/stellar-sdk";
+import { sendPurchaseConfirmationEmail } from "@/lib/email";
 
 const prisma = new PrismaClient();
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
@@ -153,6 +154,18 @@ export async function POST(req: Request) {
           descuentoActivo = regla.tipo;
           break;
         }
+      }
+
+      if (user.email) {
+        await sendPurchaseConfirmationEmail({
+          to: user.email,
+          name: user.name ?? "",
+          productName,
+          precioUSDC,
+          tokensGanados,
+          stellarTxHash,
+          purchaseId: compra.id,
+        });
       }
     }
 

--- a/app/api/pago/route.ts
+++ b/app/api/pago/route.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from "@prisma/client";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { decryptSecret } from "@/lib/encryption";
 import { registerPurchase } from "@/lib/loyaltyContract";
+import { sendPurchaseConfirmationEmail } from "@/lib/email";
 
 const prisma = new PrismaClient();
 
@@ -120,6 +121,16 @@ export async function POST(req: Request) {
         data: { used: true, usedAt: new Date() },
       });
     }
+
+    await sendPurchaseConfirmationEmail({
+      to: user.email,
+      name: user.name ?? "",
+      productName,
+      precioUSDC,
+      tokensGanados,
+      stellarTxHash: txHash,
+      purchaseId: compra.id,
+    });
 
     return NextResponse.json({
       success: true,

--- a/app/api/registro/route.ts
+++ b/app/api/registro/route.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { crearCuentaStellar, establecerTrustline } from "@/lib/stellar";
 import { encryptSecret } from "@/lib/encryption";
+import { sendWelcomeEmail } from "@/lib/email";
 
 const prisma = new PrismaClient();
 
@@ -64,6 +65,8 @@ export async function POST(req: NextRequest) {
         },
       });
     }
+
+    await sendWelcomeEmail({ to: user.email, name: user.name ?? nombre });
 
     return NextResponse.json({
       success: true,

--- a/components/emails/EmailLayout.tsx
+++ b/components/emails/EmailLayout.tsx
@@ -1,0 +1,157 @@
+// Shared HTML shell for all RIZO transactional emails.
+// Table-based layout with inline styles for email-client compatibility (no Tailwind/CSS files).
+
+export const RIZO_COLORS = {
+  purpleDark: "#2E1065",
+  purple: "#4C1D95",
+  mint: "#2DD4BF",
+  mintLight: "#CCFBF1",
+  ink: "#1E1B2E",
+  muted: "#6B7280",
+  border: "#E5E7EB",
+  background: "#F4F1FA",
+};
+
+type EmailLayoutProps = {
+  preheader: string;
+  children: React.ReactNode;
+};
+
+export default function EmailLayout({ preheader, children }: EmailLayoutProps) {
+  return (
+    <html>
+      {/* eslint-disable-next-line @next/next/no-head-element -- standalone email HTML document, not a Next.js page */}
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>RIZO</title>
+      </head>
+      <body
+        style={{
+          margin: 0,
+          padding: 0,
+          backgroundColor: RIZO_COLORS.background,
+          fontFamily:
+            "'Helvetica Neue', Helvetica, Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "none",
+            overflow: "hidden",
+            lineHeight: "1px",
+            opacity: 0,
+            maxHeight: 0,
+            maxWidth: 0,
+          }}
+        >
+          {preheader}
+        </div>
+
+        <table
+          role="presentation"
+          width="100%"
+          cellPadding={0}
+          cellSpacing={0}
+          style={{ backgroundColor: RIZO_COLORS.background, padding: "32px 16px" }}
+        >
+          <tbody>
+            <tr>
+              <td align="center">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellPadding={0}
+                  cellSpacing={0}
+                  style={{
+                    maxWidth: 480,
+                    backgroundColor: "#FFFFFF",
+                    borderRadius: 20,
+                    overflow: "hidden",
+                    border: `1px solid ${RIZO_COLORS.border}`,
+                  }}
+                >
+                  <tbody>
+                    <tr>
+                      <td
+                        style={{
+                          backgroundColor: RIZO_COLORS.purpleDark,
+                          padding: "28px 32px",
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontSize: 22,
+                            fontWeight: 700,
+                            color: RIZO_COLORS.mint,
+                            letterSpacing: 1,
+                          }}
+                        >
+                          RIZO
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style={{ padding: "32px" }}>{children}</td>
+                    </tr>
+                    <tr>
+                      <td
+                        style={{
+                          padding: "20px 32px",
+                          backgroundColor: RIZO_COLORS.background,
+                          borderTop: `1px solid ${RIZO_COLORS.border}`,
+                        }}
+                      >
+                        <p
+                          style={{
+                            margin: 0,
+                            fontSize: 12,
+                            color: RIZO_COLORS.muted,
+                            textAlign: "center",
+                          }}
+                        >
+                          RIZO — la comunidad para el pelo rizado
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  );
+}
+
+export function EmailButton({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <table role="presentation" cellPadding={0} cellSpacing={0} style={{ margin: "24px 0" }}>
+      <tbody>
+        <tr>
+          <td
+            style={{
+              backgroundColor: RIZO_COLORS.mint,
+              borderRadius: 999,
+            }}
+          >
+            <a
+              href={href}
+              style={{
+                display: "inline-block",
+                padding: "12px 28px",
+                fontSize: 14,
+                fontWeight: 600,
+                color: RIZO_COLORS.purpleDark,
+                textDecoration: "none",
+              }}
+            >
+              {children}
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/components/emails/PurchaseConfirmation.tsx
+++ b/components/emails/PurchaseConfirmation.tsx
@@ -1,0 +1,84 @@
+import EmailLayout, { EmailButton, RIZO_COLORS } from "./EmailLayout";
+
+export type PurchaseConfirmationProps = {
+  name: string;
+  productName: string;
+  precioUSDC: number;
+  tokensGanados: number;
+  stellarTxHash: string;
+  explorerUrl: string;
+  purchaseId: string;
+};
+
+export default function PurchaseConfirmation({
+  name,
+  productName,
+  precioUSDC,
+  tokensGanados,
+  stellarTxHash,
+  explorerUrl,
+  purchaseId,
+}: PurchaseConfirmationProps) {
+  return (
+    <EmailLayout preheader={`Tu compra de ${productName} fue confirmada.`}>
+      <h1
+        style={{
+          margin: "0 0 12px",
+          fontSize: 22,
+          fontWeight: 700,
+          color: RIZO_COLORS.purpleDark,
+        }}
+      >
+        ¡Gracias por tu compra, {name}!
+      </h1>
+      <p style={{ margin: "0 0 20px", fontSize: 14, lineHeight: 1.6, color: RIZO_COLORS.ink }}>
+        Confirmamos tu pedido. Aquí está el detalle:
+      </p>
+
+      <table
+        role="presentation"
+        width="100%"
+        cellPadding={0}
+        cellSpacing={0}
+        style={{
+          backgroundColor: RIZO_COLORS.background,
+          borderRadius: 12,
+          padding: "16px 20px",
+        }}
+      >
+        <tbody>
+          {[
+            ["Producto", productName],
+            ["Monto pagado", `${precioUSDC.toFixed(2)} USDC`],
+            ["Tokens ganados", `+${tokensGanados} RIZO`],
+            ["ID de pedido", purchaseId],
+          ].map(([label, value]) => (
+            <tr key={label}>
+              <td style={{ padding: "4px 0", fontSize: 12, color: RIZO_COLORS.muted, width: 130 }}>
+                {label}
+              </td>
+              <td style={{ padding: "4px 0", fontSize: 13, fontWeight: 600, color: RIZO_COLORS.ink }}>
+                {value}
+              </td>
+            </tr>
+          ))}
+          <tr>
+            <td style={{ padding: "4px 0", fontSize: 12, color: RIZO_COLORS.muted, verticalAlign: "top" }}>
+              Stellar Tx Hash
+            </td>
+            <td style={{ padding: "4px 0", fontSize: 11, fontFamily: "monospace", color: RIZO_COLORS.ink, wordBreak: "break-all" }}>
+              {stellarTxHash}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <EmailButton href={explorerUrl}>Verificar en Stellar</EmailButton>
+
+      <p style={{ margin: 0, fontSize: 12, color: RIZO_COLORS.muted }}>
+        Puedes verificar esta transacción de forma independiente en la red Stellar usando el
+        enlace de arriba.
+      </p>
+    </EmailLayout>
+  );
+}

--- a/components/emails/ResetPasswordEmail.tsx
+++ b/components/emails/ResetPasswordEmail.tsx
@@ -1,0 +1,40 @@
+import EmailLayout, { EmailButton, RIZO_COLORS } from "./EmailLayout";
+
+export type ResetPasswordEmailProps = {
+  name: string;
+  resetUrl: string;
+};
+
+export default function ResetPasswordEmail({ name, resetUrl }: ResetPasswordEmailProps) {
+  return (
+    <EmailLayout preheader="Restablece tu contraseña de RIZO. El enlace expira en 1 hora.">
+      <h1
+        style={{
+          margin: "0 0 12px",
+          fontSize: 22,
+          fontWeight: 700,
+          color: RIZO_COLORS.purpleDark,
+        }}
+      >
+        Restablece tu contraseña
+      </h1>
+      <p style={{ margin: "0 0 8px", fontSize: 14, lineHeight: 1.6, color: RIZO_COLORS.ink }}>
+        Hola {name}, recibimos una solicitud para restablecer la contraseña de tu cuenta RIZO.
+      </p>
+      <p style={{ margin: "0 0 20px", fontSize: 14, lineHeight: 1.6, color: RIZO_COLORS.ink }}>
+        Haz clic en el botón de abajo para elegir una nueva contraseña.
+      </p>
+
+      <EmailButton href={resetUrl}>Restablecer contraseña</EmailButton>
+
+      <p style={{ margin: "0 0 4px", fontSize: 12, color: RIZO_COLORS.muted }}>
+        Este enlace es válido por <strong>1 hora</strong> y solo puede usarse{" "}
+        <strong>una vez</strong>.
+      </p>
+      <p style={{ margin: 0, fontSize: 12, color: RIZO_COLORS.muted }}>
+        Si tú no solicitaste este cambio, puedes ignorar este correo — tu contraseña no será
+        modificada.
+      </p>
+    </EmailLayout>
+  );
+}

--- a/components/emails/WelcomeEmail.tsx
+++ b/components/emails/WelcomeEmail.tsx
@@ -1,0 +1,53 @@
+import EmailLayout, { EmailButton, RIZO_COLORS } from "./EmailLayout";
+
+export type WelcomeEmailProps = {
+  name: string;
+  appUrl: string;
+};
+
+export default function WelcomeEmail({ name, appUrl }: WelcomeEmailProps) {
+  return (
+    <EmailLayout preheader={`Bienvenida a RIZO, ${name}. Tu comunidad de pelo rizado te espera.`}>
+      <h1
+        style={{
+          margin: "0 0 12px",
+          fontSize: 22,
+          fontWeight: 700,
+          color: RIZO_COLORS.purpleDark,
+        }}
+      >
+        ¡Bienvenida a RIZO, {name}!
+      </h1>
+      <p style={{ margin: "0 0 20px", fontSize: 14, lineHeight: 1.6, color: RIZO_COLORS.ink }}>
+        Nos alegra tenerte en la comunidad hecha por y para el pelo rizado. En RIZO vas a
+        encontrar:
+      </p>
+
+      <table role="presentation" cellPadding={0} cellSpacing={0} width="100%">
+        <tbody>
+          {[
+            ["🌀", "Contenido y comunidad curada para cada tipo de rizo, del 2A al 4C."],
+            ["💧", "Tienda con productos verificados por su ficha capilar, no por moda."],
+            ["✂️", "Estilistas especializados en rizos cerca de ti."],
+            ["🪙", "Tokens RIZO en Stellar por cada compra, canjeables por descuentos reales."],
+          ].map(([emoji, text]) => (
+            <tr key={text}>
+              <td style={{ padding: "6px 0", verticalAlign: "top", width: 28, fontSize: 16 }}>
+                {emoji}
+              </td>
+              <td style={{ padding: "6px 0", fontSize: 14, lineHeight: 1.5, color: RIZO_COLORS.ink }}>
+                {text}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <EmailButton href={appUrl}>Explorar RIZO</EmailButton>
+
+      <p style={{ margin: 0, fontSize: 12, color: RIZO_COLORS.muted }}>
+        Ya ganaste 20 tokens de bienvenida — revísalos en tu perfil.
+      </p>
+    </EmailLayout>
+  );
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,123 @@
+/**
+ * lib/email.ts
+ * Transactional email sending via Resend. Server-side only.
+ * Each send* function swallows its own errors (logs and returns success:false)
+ * so a failed email never breaks the registration/purchase/reset flow that triggered it.
+ */
+
+import { Resend } from "resend";
+import { renderToStaticMarkup } from "react-dom/server";
+import WelcomeEmail from "@/components/emails/WelcomeEmail";
+import PurchaseConfirmation from "@/components/emails/PurchaseConfirmation";
+import ResetPasswordEmail from "@/components/emails/ResetPasswordEmail";
+
+let resendClient: Resend | null = null;
+
+function getResendClient(): Resend {
+  if (!resendClient) {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error("RESEND_API_KEY no está configurado");
+    }
+    resendClient = new Resend(apiKey);
+  }
+  return resendClient;
+}
+
+function getEmailFrom(): string {
+  return process.env.EMAIL_FROM || "RIZO <noreply@rizo.app>";
+}
+
+function getAppUrl(): string {
+  return process.env.NEXTAUTH_URL || "http://localhost:3000";
+}
+
+function getExplorerUrl(txHash: string): string {
+  const network = process.env.STELLAR_NETWORK === "mainnet" ? "public" : "testnet";
+  return `https://stellar.expert/explorer/${network}/tx/${txHash}`;
+}
+
+type SendResult = { success: boolean; error?: string };
+
+export async function sendWelcomeEmail(params: {
+  to: string;
+  name: string;
+}): Promise<SendResult> {
+  try {
+    const html = renderToStaticMarkup(
+      WelcomeEmail({ name: params.name, appUrl: getAppUrl() })
+    );
+
+    await getResendClient().emails.send({
+      from: getEmailFrom(),
+      to: params.to,
+      subject: `¡Bienvenida a RIZO, ${params.name}!`,
+      html: `<!DOCTYPE html>${html}`,
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error("[lib/email] sendWelcomeEmail falló:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function sendPurchaseConfirmationEmail(params: {
+  to: string;
+  name: string;
+  productName: string;
+  precioUSDC: number;
+  tokensGanados: number;
+  stellarTxHash: string;
+  purchaseId: string;
+}): Promise<SendResult> {
+  try {
+    const html = renderToStaticMarkup(
+      PurchaseConfirmation({
+        name: params.name,
+        productName: params.productName,
+        precioUSDC: params.precioUSDC,
+        tokensGanados: params.tokensGanados,
+        stellarTxHash: params.stellarTxHash,
+        purchaseId: params.purchaseId,
+        explorerUrl: getExplorerUrl(params.stellarTxHash),
+      })
+    );
+
+    await getResendClient().emails.send({
+      from: getEmailFrom(),
+      to: params.to,
+      subject: `Compra confirmada: ${params.productName}`,
+      html: `<!DOCTYPE html>${html}`,
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error("[lib/email] sendPurchaseConfirmationEmail falló:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function sendPasswordResetEmail(params: {
+  to: string;
+  name: string;
+  resetUrl: string;
+}): Promise<SendResult> {
+  try {
+    const html = renderToStaticMarkup(
+      ResetPasswordEmail({ name: params.name, resetUrl: params.resetUrl })
+    );
+
+    await getResendClient().emails.send({
+      from: getEmailFrom(),
+      to: params.to,
+      subject: "Restablece tu contraseña de RIZO",
+      html: `<!DOCTYPE html>${html}`,
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error("[lib/email] sendPasswordResetEmail falló:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "rizo-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "@prisma/adapter-neon": "^7.5.0",
@@ -26,6 +27,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-leaflet": "^5.0.0",
+        "resend": "^6.22.1",
         "stream-browserify": "^3.0.0",
         "ws": "^8.19.0"
       },
@@ -40,6 +42,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
         "tailwindcss": "^4",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       }
     },
@@ -453,6 +456,30 @@
         "clsx": "^1.2.1",
         "eventemitter3": "^5.0.1",
         "preact": "^10.24.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@ecies/ciphers": {
@@ -3155,17 +3182,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.9.tgz",
@@ -3569,17 +3585,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@reown/appkit-wallet": {
@@ -4016,17 +4021,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -5235,6 +5229,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@stellar/freighter-api": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
@@ -5701,6 +5701,34 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -8348,6 +8376,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -8413,6 +8454,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9229,6 +9277,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -9522,6 +9577,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dijkstrajs": {
@@ -10637,6 +10702,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
@@ -12438,6 +12509,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -13504,6 +13582,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -13938,6 +14022,27 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/resend": {
+      "version": "6.22.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.22.1.tgz",
+      "integrity": "sha512-VqYhB6zqsifujJfZsiTKBVcZaKih0XitdXHCte4x4d7KH4D0QvPx5GvqcypCn2y64tK0C/6OskpQvsaSJaHHBw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -14496,6 +14601,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -15012,6 +15127,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -15479,6 +15638,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/valtio": {
       "version": "2.1.7",
@@ -15968,6 +16134,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-leaflet": "^5.0.0",
+    "resend": "^6.22.1",
     "stream-browserify": "^3.0.0",
     "ws": "^8.19.0"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,12 +24,23 @@ model User {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
-  posts         Post[]
-  tokenTxs      TokenTransaction[]
-  appointments  Appointment[]
-  reviews       Review[]
-  purchases     Purchase[]
-  discountCodes DiscountCode[]
+  posts               Post[]
+  tokenTxs            TokenTransaction[]
+  appointments        Appointment[]
+  reviews             Review[]
+  purchases           Purchase[]
+  discountCodes       DiscountCode[]
+  passwordResetTokens PasswordResetToken[]
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String    @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
 }
 
 model Purchase {


### PR DESCRIPTION
Closes #19 
Transactional emails — welcome, purchase confirmation, password reset (#19)

Adds Resend-powered transactional emails and a working password reset flow.

- **`lib/email.ts`** — Resend client + `sendWelcomeEmail`, `sendPurchaseConfirmationEmail`, `sendPasswordResetEmail` (errors are swallowed/logged so a mail failure never breaks the triggering request)
- **`components/emails/`** — `EmailLayout` (dark purple + mint green brand shell), `WelcomeEmail`, `PurchaseConfirmation`, `ResetPasswordEmail`
- **`app/api/auth/reset-password/route.ts`** — `POST` requests a reset (generic response, no email enumeration), `PUT` confirms with a single-use, 1-hour token (SHA-256 hashed at rest)
- **`app/(auth)/olvide-password`** and **`restablecer-password`** pages wired to the existing "¿Olvidaste tu contraseña?" link
- Wired welcome email into `registro`, purchase confirmation into `pago` and `compra`
- `prisma/schema.prisma` — new `PasswordResetToken` model (schema only, no migration generated — no DB access in sandbox)
- `.env.example` — documented `RESEND_API_KEY`, `EMAIL_FROM`
- `tsc` + `eslint` clean