### PR TITLE
Follow system: Follow button and filtered feed UI

### DIFF
--- a/app/(main)/comunidad/page.tsx
+++ b/app/(main)/comunidad/page.tsx
@@ -1,8 +1,11 @@
 "use client";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useSession } from "next-auth/react";
+import { useAccesly } from "accesly";
 import CreatePost from "@/components/feed/CreatePost";
 import PostCard from "@/components/feed/PostCard";
 import Sidebar from "@/components/feed/Sidebar";
+import { getFollowingIds } from "@/lib/mockFollow";
 
 type Post = {
   id: string;
@@ -37,8 +40,14 @@ function formatTiempo(fecha: string): string {
 }
 
 export default function ComunidadPage() {
+  const { data: session } = useSession();
+  const { wallet } = useAccesly();
+  const userEmail = wallet?.email || session?.user?.email;
+
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
+  const [feedTab, setFeedTab] = useState<"todos" | "siguiendo">("todos");
+  const [followingIds, setFollowingIds] = useState<string[]>([]);
 
   const cargarPosts = useCallback(async () => {
     try {
@@ -56,6 +65,16 @@ export default function ComunidadPage() {
     cargarPosts();
   }, [cargarPosts]);
 
+  // Mocked locally until issue #12's follow API lands — see lib/mockFollow.ts.
+  useEffect(() => {
+    if (userEmail) setFollowingIds(getFollowingIds(userEmail));
+  }, [userEmail, feedTab]);
+
+  const postsVisibles = useMemo(() => {
+    if (feedTab === "todos") return posts;
+    return posts.filter((p) => followingIds.includes(p.user.id));
+  }, [posts, feedTab, followingIds]);
+
   return (
     <div className="max-w-6xl mx-auto px-6 py-8">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -67,6 +86,26 @@ export default function ComunidadPage() {
             Comunidad
           </h1>
           <CreatePost onPostCreado={cargarPosts} />
+
+          {/* Tabs: Todos / Siguiendo */}
+          <div className="flex gap-1 bg-white rounded-2xl p-1 border border-[#D7CCC8]">
+            {[
+              { id: "todos", label: "Todos" },
+              { id: "siguiendo", label: "Siguiendo" },
+            ].map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setFeedTab(t.id as typeof feedTab)}
+                className="flex-1 py-2.5 rounded-xl text-sm font-medium transition-all"
+                style={{
+                  backgroundColor: feedTab === t.id ? "#8D6E63" : "transparent",
+                  color: feedTab === t.id ? "white" : "#A1887F",
+                }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
 
           {loading && (
             <div className="flex flex-col gap-4">
@@ -86,7 +125,8 @@ export default function ComunidadPage() {
             </div>
           )}
 
-          {!loading && posts.length === 0 && (
+          {/* Estado vacío: feed general sin publicaciones */}
+          {!loading && feedTab === "todos" && postsVisibles.length === 0 && (
             <div className="flex flex-col items-center justify-center py-20 text-center bg-white rounded-2xl border border-[#D7CCC8]">
               <span className="text-4xl mb-4">🌀</span>
               <p className="text-sm font-semibold text-[#3E2723]">No hay publicaciones aun</p>
@@ -94,9 +134,27 @@ export default function ComunidadPage() {
             </div>
           )}
 
-          {!loading && posts.length > 0 && posts.map((post) => (
+          {/* Estado vacío diseñado: pestaña Siguiendo sin seguidos, o sin posts de ellos */}
+          {!loading && feedTab === "siguiendo" && postsVisibles.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-center bg-white rounded-2xl border border-[#D7CCC8]">
+              <span className="text-4xl mb-4">🫶</span>
+              <p className="text-sm font-semibold text-[#3E2723]">
+                {followingIds.length === 0
+                  ? "Aun no sigues a nadie"
+                  : "Las personas que sigues no han publicado todavia"}
+              </p>
+              <p className="text-xs text-[#A1887F] mt-1">
+                {followingIds.length === 0
+                  ? "Sigue a otras usuarias para ver sus publicaciones aqui"
+                  : "Vuelve mas tarde para ver sus novedades"}
+              </p>
+            </div>
+          )}
+
+          {!loading && postsVisibles.length > 0 && postsVisibles.map((post) => (
             <PostCard key={post.id} post={{
-              id: post.id as any,
+              id: post.id,
+              userId: post.user.id,
               autor: post.user.name || "Usuario",
               handle: `@${post.user.email.split("@")[0]}`,
               avatar: post.user.name?.[0]?.toUpperCase() ?? "U",

--- a/app/api/user/me/route.ts
+++ b/app/api/user/me/route.ts
@@ -6,12 +6,13 @@ const prisma = new PrismaClient();
 export async function GET(req: NextRequest) {
   try {
     const email = req.nextUrl.searchParams.get("email");
-    if (!email) {
-      return NextResponse.json({ error: "Email requerido" }, { status: 400 });
+    const id = req.nextUrl.searchParams.get("id");
+    if (!email && !id) {
+      return NextResponse.json({ error: "Email o id requerido" }, { status: 400 });
     }
 
     const user = await prisma.user.findUnique({
-      where: { email },
+      where: id ? { id } : { email: email as string },
       select: {
         id: true,
         email: true,

--- a/components/feed/PostCard.tsx
+++ b/components/feed/PostCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useState } from "react";
+import Link from "next/link";
 
 type Post = {
-  id: number;
+  id: string;
+  userId: string;
   autor: string;
   handle: string;
   avatar: string;
@@ -31,14 +33,14 @@ export default function PostCard({ post }: { post: Post }) {
 
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <Link href={`/perfil?usuario=${post.userId}`} className="flex items-center gap-3 group">
           <div className="w-10 h-10 rounded-full bg-[#D7CCC8] flex items-center justify-center text-lg font-bold text-[#8D6E63]"
             style={{ fontFamily: "var(--font-playfair)" }}>
             {post.avatar}
           </div>
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-[#3E2723]">{post.autor}</span>
+              <span className="text-sm font-semibold text-[#3E2723] group-hover:underline">{post.autor}</span>
               {post.tipo !== "rizada" && (
                 <span className="text-xs px-2 py-0.5 rounded-full font-medium"
                   style={{ backgroundColor: badge.bg, color: badge.text }}>
@@ -48,7 +50,7 @@ export default function PostCard({ post }: { post: Post }) {
             </div>
             <span className="text-xs text-[#A1887F]">{post.handle} · {post.tiempo}</span>
           </div>
-        </div>
+        </Link>
         <button className="text-[#A1887F] hover:text-[#8D6E63] text-lg">···</button>
       </div>
 

--- a/components/perfil/FollowButton.tsx
+++ b/components/perfil/FollowButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useState } from "react";
+import { toggleFollow } from "@/lib/mockFollow";
+
+type FollowButtonProps = {
+  /** Email of the currently logged-in user (the one doing the following). */
+  viewerEmail: string;
+  /** ID of the profile being viewed (the one being followed). */
+  targetUserId: string;
+  /** Whether the viewer already follows this user, from the initial page load. */
+  initialFollowing: boolean;
+  /** Called after a successful toggle, so the parent can update counters. */
+  onChange?: (following: boolean) => void;
+};
+
+export default function FollowButton({
+  viewerEmail,
+  targetUserId,
+  initialFollowing,
+  onChange,
+}: FollowButtonProps) {
+  const [following, setFollowing] = useState(initialFollowing);
+  const [pending, setPending] = useState(false);
+
+  async function handleClick() {
+    if (pending) return;
+
+    // Optimistic update: flip the UI immediately, before the API responds.
+    const optimisticNext = !following;
+    setFollowing(optimisticNext);
+    setPending(true);
+
+    try {
+      const result = await toggleFollow(viewerEmail, targetUserId);
+      setFollowing(result.following);
+      onChange?.(result.following);
+    } catch {
+      // Roll back to the previous state if the request fails.
+      setFollowing(!optimisticNext);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={pending}
+      aria-pressed={following}
+      className="px-5 py-2 rounded-full text-xs font-medium transition-colors disabled:opacity-60"
+      style={
+        following
+          ? {
+              backgroundColor: "white",
+              color: "#8D6E63",
+              border: "1px solid #D7CCC8",
+            }
+          : {
+              backgroundColor: "#8D6E63",
+              color: "white",
+              border: "1px solid #8D6E63",
+            }
+      }
+    >
+      {following ? "Siguiendo" : "Seguir"}
+    </button>
+  );
+}

--- a/components/profile/PerfilPage.tsx
+++ b/components/profile/PerfilPage.tsx
@@ -2,7 +2,10 @@
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useAccesly } from "accesly";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
+import FollowButton from "@/components/perfil/FollowButton";
+import { getFollowingCount, getFollowerCount, isFollowing } from "@/lib/mockFollow";
 
 type UserProfile = {
   id: string;
@@ -26,25 +29,54 @@ const ROLE_LABELS: Record<string, { label: string; color: string }> = {
 export default function PerfilPage() {
   const { data: session } = useSession();
   const { wallet } = useAccesly();
+  const searchParams = useSearchParams();
   const [tab, setTab] = useState<"publicaciones" | "resenas" | "guardados">("publicaciones");
   const [perfil, setPerfil] = useState<UserProfile | null>(null);
   const [cargando, setCargando] = useState(true);
+  const [following, setFollowing] = useState(false);
+  const [followerCount, setFollowerCount] = useState(0);
+  const [followingCount, setFollowingCount] = useState(0);
 
   const userEmail = session?.user?.email || wallet?.email;
+  // Viewing someone else's profile via /perfil?usuario=<id>. Falls back to
+  // the logged-in user's own profile when absent.
+  const viewedUserId = searchParams.get("usuario");
+  const isOwnProfile = !viewedUserId;
+
   const userInicial = perfil?.name?.[0]?.toUpperCase() || userEmail?.[0]?.toUpperCase() || "?";
   const username = perfil?.email?.split("@")[0] || "";
   const roleInfo = ROLE_LABELS[perfil?.role ?? "RIZADA"] ?? ROLE_LABELS.RIZADA;
 
   useEffect(() => {
-    if (!userEmail) { setCargando(false); return; }
-    fetch(`/api/user/me?email=${encodeURIComponent(userEmail)}`)
+    if (isOwnProfile && !userEmail) { setCargando(false); return; }
+
+    const query = isOwnProfile
+      ? `email=${encodeURIComponent(userEmail as string)}`
+      : `id=${encodeURIComponent(viewedUserId as string)}`;
+
+    fetch(`/api/user/me?${query}`)
       .then((r) => r.json())
-      .then((data) => { if (data.id) setPerfil(data); })
+      .then((data) => {
+        if (!data.id) return;
+        setPerfil(data);
+
+        // Follow state and counters are derived from the profile just
+        // loaded (mocked locally until #12's API lands — see lib/mockFollow.ts).
+        setFollowerCount(getFollowerCount(data.id));
+        setFollowingCount(
+          isOwnProfile && userEmail
+            ? getFollowingCount(userEmail)
+            : getFollowingCount(data.email),
+        );
+        if (!isOwnProfile && userEmail) {
+          setFollowing(isFollowing(userEmail, data.id));
+        }
+      })
       .catch(console.error)
       .finally(() => setCargando(false));
-  }, [userEmail]);
+  }, [isOwnProfile, userEmail, viewedUserId]);
 
-  if (!userEmail) {
+  if (isOwnProfile && !userEmail) {
     return (
       <div className="max-w-4xl mx-auto px-6 py-20 text-center">
         <p className="text-[#A1887F] text-sm mb-4">Inicia sesion para ver tu perfil</p>
@@ -60,6 +92,14 @@ export default function PerfilPage() {
     return (
       <div className="max-w-4xl mx-auto px-6 py-20 text-center">
         <div className="w-8 h-8 border-2 border-[#8D6E63] border-t-transparent rounded-full animate-spin mx-auto" />
+      </div>
+    );
+  }
+
+  if (!isOwnProfile && !perfil) {
+    return (
+      <div className="max-w-4xl mx-auto px-6 py-20 text-center">
+        <p className="text-[#A1887F] text-sm">No se encontro este perfil</p>
       </div>
     );
   }
@@ -81,11 +121,26 @@ export default function PerfilPage() {
           </div>
         </div>
 
-        {/* Boton editar */}
+        {/* Boton editar / seguir */}
         <div className="absolute bottom-4 right-4">
-          <button className="bg-white border border-[#D7CCC8] text-[#4E342E] px-4 py-2 rounded-full text-xs font-medium hover:bg-[#FAF8F5] transition-colors">
-            Editar perfil
-          </button>
+          {isOwnProfile ? (
+            <button className="bg-white border border-[#D7CCC8] text-[#4E342E] px-4 py-2 rounded-full text-xs font-medium hover:bg-[#FAF8F5] transition-colors">
+              Editar perfil
+            </button>
+          ) : (
+            userEmail &&
+            perfil && (
+              <FollowButton
+                viewerEmail={userEmail}
+                targetUserId={perfil.id}
+                initialFollowing={following}
+                onChange={(next) => {
+                  setFollowing(next);
+                  setFollowerCount((c) => (next ? c + 1 : Math.max(0, c - 1)));
+                }}
+              />
+            )
+          )}
         </div>
       </div>
 
@@ -116,25 +171,28 @@ export default function PerfilPage() {
         </div>
 
         {/* Tokens */}
-        <div className="bg-white rounded-2xl border border-[#D7CCC8] px-6 py-4 flex flex-col items-center min-w-32">
-          <p className="text-xs text-[#A1887F] mb-1">Mis tokens</p>
-          <span className="text-3xl font-bold text-[#8D6E63]"
-            style={{ fontFamily: "var(--font-playfair)" }}>
-            {perfil?.tokens ?? 0}
-          </span>
-          <span className="text-xs text-[#A1887F]">RIZO tokens</span>
-          <Link href="/recompensas"
-            className="mt-2 text-xs text-[#8D6E63] hover:underline">
-            Ver recompensas
-          </Link>
-        </div>
+        {isOwnProfile && (
+          <div className="bg-white rounded-2xl border border-[#D7CCC8] px-6 py-4 flex flex-col items-center min-w-32">
+            <p className="text-xs text-[#A1887F] mb-1">Mis tokens</p>
+            <span className="text-3xl font-bold text-[#8D6E63]"
+              style={{ fontFamily: "var(--font-playfair)" }}>
+              {perfil?.tokens ?? 0}
+            </span>
+            <span className="text-xs text-[#A1887F]">RIZO tokens</span>
+            <Link href="/recompensas"
+              className="mt-2 text-xs text-[#8D6E63] hover:underline">
+              Ver recompensas
+            </Link>
+          </div>
+        )}
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-4 bg-white rounded-2xl border border-[#D7CCC8] p-5 mb-6">
+      <div className="grid grid-cols-4 gap-4 bg-white rounded-2xl border border-[#D7CCC8] p-5 mb-6">
         {[
           { label: "Publicaciones", valor: perfil?._count?.posts ?? 0 },
-          { label: "Seguidores", valor: 0 },
+          { label: "Seguidores", valor: followerCount },
+          { label: "Siguiendo", valor: followingCount },
           { label: "Resenas", valor: perfil?._count?.reviews ?? 0 },
         ].map((stat) => (
           <div key={stat.label} className="text-center">

--- a/lib/mockFollow.ts
+++ b/lib/mockFollow.ts
@@ -1,0 +1,102 @@
+/**
+ * lib/mockFollow.ts
+ *
+ * TEMPORARY client-side mock for the follow/unfollow feature (#14).
+ *
+ * Issue #12 (the real follow API + DB model) has not been merged yet, and
+ * this issue is explicitly frontend-only ("The API endpoints will be
+ * handled in a separate issue (#12)... Requires issue #12 to be merged
+ * first, or mock the response locally"). Building a real Follow table /
+ * API route here would duplicate #12's work, so this module stores follow
+ * relationships in localStorage instead — good enough to exercise every
+ * UI state (optimistic toggle, counters, Following tab, empty state)
+ * without a backend.
+ *
+ * Known limitation: localStorage is per-browser, so two accounts tested in
+ * two separate browser profiles/incognito windows will NOT see each
+ * other's follow state live. That's expected for a local mock; real
+ * cross-account persistence arrives with #12.
+ *
+ * TO REPLACE WITH THE REAL API (once #12 merges):
+ *   - toggleFollow()      -> POST /api/follow/:userId (or similar)
+ *   - isFollowing()       -> derive from the real API's response
+ *   - getFollowingIds()   -> GET /api/follow/following?userId=...
+ *   - getFollowerCount()  -> included in the user's profile payload
+ *   - getFollowingCount() -> included in the user's profile payload
+ * The FollowButton component only calls the functions below, so swapping
+ * their internals for real fetch() calls is the only change needed.
+ */
+
+const STORAGE_KEY = "rizo_mock_follows_v1";
+
+// Map of "follower's email" -> array of followed user IDs.
+type FollowStore = Record<string, string[]>;
+
+function readStore(): FollowStore {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as FollowStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: FollowStore): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+/** Whether `followerEmail` currently follows `targetUserId`. */
+export function isFollowing(followerEmail: string, targetUserId: string): boolean {
+  const store = readStore();
+  return (store[followerEmail] ?? []).includes(targetUserId);
+}
+
+/**
+ * Toggles the follow relationship and returns the new state.
+ * Simulates a network round-trip so callers can exercise optimistic-update
+ * and rollback logic the same way they will against the real API.
+ */
+export async function toggleFollow(
+  followerEmail: string,
+  targetUserId: string,
+): Promise<{ following: boolean }> {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+
+  const store = readStore();
+  const current = new Set(store[followerEmail] ?? []);
+  const willFollow = !current.has(targetUserId);
+
+  if (willFollow) {
+    current.add(targetUserId);
+  } else {
+    current.delete(targetUserId);
+  }
+
+  store[followerEmail] = Array.from(current);
+  writeStore(store);
+
+  return { following: willFollow };
+}
+
+/** All user IDs that `followerEmail` currently follows. */
+export function getFollowingIds(followerEmail: string): string[] {
+  const store = readStore();
+  return store[followerEmail] ?? [];
+}
+
+/** How many users `followerEmail` currently follows. */
+export function getFollowingCount(followerEmail: string): number {
+  return getFollowingIds(followerEmail).length;
+}
+
+/**
+ * How many (mocked) followers `targetUserId` has, counted across every
+ * follower list in the local store. Only reflects follows made in this
+ * browser — a real count will come from #12's API.
+ */
+export function getFollowerCount(targetUserId: string): number {
+  const store = readStore();
+  return Object.values(store).filter((followedIds) => followedIds.includes(targetUserId)).length;
+}


### PR DESCRIPTION
Closes #14

What this covers

This is the frontend-only piece described in the issue — the real follow API and DB model are issue #12, which hasn't merged yet. Since the issue explicitly allows mocking the response locally until #12 lands, I built a small localStorage-backed mock (lib/mockFollow.ts) that's clearly documented as temporary, with a comment showing exactly what to swap for real API calls once #12 ships.

A couple of things came up that weren't in the original file list but were needed to make the feature actually usable:

There was no existing way to view someone else's profile at all — /perfil only ever showed your own. I added support for /perfil?usuario=<id> so a profile can be viewed with real follower/following/post counts and the follow button. Your own profile still works exactly as before, just with real counters instead of hardcoded 0.

Post authors in the feed weren't linked to anything, so there was no way to reach another user's profile in the first place. I made the author name/avatar in PostCard link to their profile.

/api/user/me only supported lookup by email. I added a small, backward-compatible id query param option, needed to fetch another user's profile data.

What's in each file

lib/mockFollow.ts (new): follow/unfollow, follower and following counts, all persisted in localStorage, with a short simulated delay so the optimistic-update logic gets exercised the same way it will against the real API later.

components/perfil/FollowButton.tsx (new): the follow/unfollow toggle. Updates optimistically the moment you click, and rolls back if the call fails.

components/profile/PerfilPage.tsx: added the usuario query param handling, real follower/following/post counts, and shows the FollowButton when viewing someone else's profile.

app/(main)/comunidad/page.tsx: added a Todos / Siguiendo tab switcher. The Siguiendo tab has two distinct empty states — one for "you don't follow anyone yet" and a different one for "the people you follow haven't posted" — rather than just showing a blank feed either way.

components/feed/PostCard.tsx: author name and avatar now link to /perfil?usuario=<id>.

app/api/user/me/route.ts: now accepts either ?email= or ?id=.

Testing

npx tsc --noEmit passes clean.

eslint on all changed/new files: one lint rule (react-hooks/set-state-in-effect) fires on patterns already present in the existing codebase (confirmed the same error exists on unmodified main in app/(main)/comunidad/page.tsx and components/profile/PerfilPage.tsx before this change), so this isn't something introduced here.

npm run build passes.

Tested manually with two separate accounts per the issue's setup instructions: follow/unfollow toggles instantly, counters update without a page reload, and the Following tab correctly filters the feed and shows its empty state when following no one.